### PR TITLE
OSSRH Sonatype Snapshot Publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,26 +4,69 @@ executors:
   jdk-8:
     docker:
       - image: circleci/openjdk:8-jdk
+    working_directory: ~/repo
 
 jobs:
   build:
     executor: jdk-8
-    working_directory: ~/repo
     steps:
       - checkout
+
       - restore_cache:
           keys:
             - m2-{{ checksum "pom.xml" }}
             - m2-
+
       - run: mvn dependency:go-offline
+
       - save_cache:
           key: m2-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
+
       - run: mvn clean install
+
+      # Save built artifacts
+      - run: |
+          set -xu
+          mkdir -p artifacts
+          cp -r target/*.jar artifacts/
+
+      - store_artifacts:
+          path: artifacts
+          destination: jars
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - target
+
+  deploy-snapshot:
+    executor: jdk-8
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - m2-{{ checksum "pom.xml" }}
+            - m2-
+
+      - attach_workspace:
+          at: .
+
+      - run: echo -e $GPG_KEY | gpg --import --no-tty --batch --yes
+
+      - run: mvn deploy -s .circleci/settings.xml -DskipTest=true
 
 workflows:
   version: 2
-  build:
+  build-deploy:
     jobs:
       - build
+      - deploy-snapshot:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - /^release.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2.1
+
+executors:
+  jdk-8:
+    docker:
+      - image: circleci/openjdk:8-jdk
+
+jobs:
+  build:
+    executor: jdk-8
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - m2-{{ checksum "pom.xml" }}
+            - m2-
+      - run: mvn dependency:go-offline
+      - save_cache:
+          key: m2-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+      - run: mvn clean install
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd"
+          xmlns="http://maven.apache.org/SETTINGS/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <servers>
+        <server>
+            <id>ossrh</id>
+            <username>${env.OSSRH_USER}</username>
+            <password>${env.OSSRH_PASS}</password>
+        </server>
+    </servers>
+
+    <profiles>
+        <profile>
+            <id>ossrh</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <gpg.executable>gpg</gpg.executable>
+                <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+            </properties>
+        </profile>
+    </profiles>
+
+    <activeProfiles>
+        <activeProfile>ossrh</activeProfile>
+    </activeProfiles>
+</settings>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -91,6 +91,9 @@
       </list>
     </option>
   </component>
+  <component name="ProjectResources">
+    <resource url="http://maven.apache.org/xsd/settings-1.1.0.xsd" location="$APPLICATION_HOME_DIR$/plugins/maven/lib/maven.jar!/schemas/settings-1.0.0.xsd" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,46 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.eclipse.epsilon</groupId>
+  <groupId>org.eclipse.epsilon.labs</groupId>
   <artifactId>executors</artifactId>
-  <version>1.6-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
+
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description>A simple API for running Epsilon Scripts from standalone applications outside of an OSGI environment</description>
+  <url>https://github.com/epsilonlabs/Epsilon-Executors</url>
+  <inceptionYear>2019</inceptionYear>
+
+  <licenses>
+    <license>
+      <name>Eclipse Public License v2.0</name>
+      <url>https://www.eclipse.org/legal/epl-2.0/</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Horacio Hoyos</name>
+      <email>horacio.hoyos@york.ac.uk</email>
+      <organization>University of York</organization>
+      <organizationUrl>https://www.cs.york.ac.uk/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/epsilonlabs/Epsilon-Executors.git</connection>
+    <developerConnection>scm:git:https://github.com/epsilonlabs/Epsilon-Executors.git</developerConnection>
+    <url>https://github.com/epsilonlabs/Epsilon-Executors</url>
+  </scm>
+
+  <issueManagement>
+    <system>github</system>
+    <url>https://github.com/epsilonlabs/Epsilon-Executors/issues</url>
+  </issueManagement>
 
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <repositories>
@@ -23,7 +56,6 @@
       </snapshots>
     </repository>
   </repositories>
-
 
   <dependencies>
     <dependency>
@@ -38,12 +70,25 @@
     </dependency>
   </dependencies>
 
-
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -55,6 +100,5 @@
       </plugin>
     </plugins>
   </build>
-
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,13 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <repositories>
     <repository>
       <id>oss-sonatype</id>
@@ -101,4 +108,39 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>ossrh</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <!-- Required to accept GPG Passphrase from settings (for GPG v2+) -->
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>3.0.0-M1</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/src/main/java/org/eclipse/epsilon/executors/EpsilonExecutor.java
+++ b/src/main/java/org/eclipse/epsilon/executors/EpsilonExecutor.java
@@ -440,7 +440,7 @@ public class EpsilonExecutor implements Executor {
     		private T result;
             public void run() {
             	try {
-					result = invoqueExecutor();
+					result = invokeExecutor();
 				} catch (EpsilonExecutorException e) {
 					throw new RuntimeException(e);
 				}
@@ -453,7 +453,7 @@ public class EpsilonExecutor implements Executor {
 
     @Override
 	@SuppressWarnings("unchecked")
-	public <R> R invoqueExecutor() throws EpsilonExecutorException {
+	public <R> R invokeExecutor() throws EpsilonExecutorException {
         logger.info("Executing engine.");
         preProfile();
         prepareExecution();

--- a/src/main/java/org/eclipse/epsilon/executors/Executor.java
+++ b/src/main/java/org/eclipse/epsilon/executors/Executor.java
@@ -32,7 +32,7 @@ public interface Executor {
 
 	/**
 	 * Create a Runnable so the executor can be executed in a thread. Internally the
-	 * {@link #invoqueExecutor()} is called. Any exceptions will be wrapped inside a
+	 * {@link #invokeExecutor()} is called. Any exceptions will be wrapped inside a
 	 * {@link RuntimeException}.
 	 * @param <T> 			the return type of the executed module
 	 * @return  the result of the execution
@@ -45,7 +45,7 @@ public interface Executor {
 	 * @throws EpsilonExecutorException if there is an error during execution
 	 * @param <R> 			the return type of the executed module
 	 */
-	<R> R invoqueExecutor() throws EpsilonExecutorException;
+	<R> R invokeExecutor() throws EpsilonExecutorException;
 
 	/**
 	 * Disposes the executor. Implementing classes should perform any clean actions.

--- a/src/main/java/org/eclipse/epsilon/executors/ModuleWrap.java
+++ b/src/main/java/org/eclipse/epsilon/executors/ModuleWrap.java
@@ -108,7 +108,7 @@ public class ModuleWrap implements EpsilonLanguageExecutor<Object> {
 
 	@Override
 	public Object execute() throws EolRuntimeException {
-		throw new UnsupportedOperationException("The ModuleWrap does not support the ModuleWrap method.");
+		throw new UnsupportedOperationException("The ModuleWrap does not support the execute method.");
 	}
 
 }


### PR DESCRIPTION
Adds CircleCI build script and pom.xml modifications to publish the API Jar, Sources and Javadoc into the OSSRH Snapshot repository.

Currently will only deploy on branches with names beginning with `release/****`. This can be configured in the `.circleci/config.yml` file underneath `workflows`